### PR TITLE
Convert Unicode strings to UTF-8 implicitly

### DIFF
--- a/flaskext/bcrypt.py
+++ b/flaskext/bcrypt.py
@@ -22,6 +22,8 @@ def generate_password_hash(password, rounds=None):
     if not password:
         raise ValueError('Password must be non-empty.')
     
+    if isinstance(password, unicode):
+        password = password.encode('u8')
     password = str(password)
     
     pw_hash = bcrypt.hashpw(password, bcrypt.gensalt(rounds))
@@ -48,5 +50,9 @@ def check_password_hash(pw_hash, password):
     
     Returns `True` if the password matched, `False` otherwise.
     '''
+
+    if isinstance(password, unicode):
+        password = password.encode('u8')
+    password = str(password)
     
     return constant_time_compare(bcrypt.hashpw(password, pw_hash), pw_hash)

--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -31,6 +31,23 @@ class BasicTestCase(unittest.TestCase):
         # check a wrong password
         b = check_password_hash(self.pw_hash, 'test')
         self.assertFalse(b)
+
+    def test_check_hash_unicode(self):
+        password=u'\u2603'
+        x = generate_password_hash(password)
+        # check a correct password
+        a = check_password_hash(x, password)
+        self.assertTrue(a)
+        # check a wrong password
+        b = check_password_hash(x, 'test')
+        self.assertFalse(b)
+
+    def test_check_hash_unicode_is_utf8(self):
+        password=u'\u2603'
+        x = generate_password_hash(password)
+        # check a correct password
+        a = check_password_hash(x, '\xe2\x98\x83')
+        self.assertTrue(a)
     
     def test_rounds_set(self):
         self.assertTrue(sys.modules['flaskext.bcrypt']._log_rounds[0] == 6)


### PR DESCRIPTION
Strings which come from MongoDB and XML are generally Unicode; using x.encode('u8') all over code which needs to call this library seems like a bad place- if everything gets encoded down to UTF-8 if it's not already a string, and it's done consistently, that seems harmless.
