### PR TITLE
Modify to use python-bcrypt

### DIFF
--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -11,7 +11,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-__version_info__ = ('0', '6', '0')
+__version_info__ = ('0', '6', '1')
 __version__ = '.'.join(__version_info__)
 __author__ = 'Max Countryman'
 __license__ = 'BSD'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules=['flask_bcrypt'],
     zip_safe=False,
     platforms='any',
-    install_requires=['Flask', 'py-bcrypt'],
+    install_requires=['Flask', 'python-bcrypt'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
py-bcrypt is outdated and not cross-platform anymore, it does not
cleanly build on windows.

python-bcrypt is a fork that is still maintained, and compiles cleanly
across many operating systems.
