### PR TITLE
use bcrypt instead of py-bcrypt for supporting Windows + python3

### DIFF
--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -160,7 +160,14 @@ class Bcrypt(object):
             password = str(password)
         else:
             password = str(password).encode('utf-8')
-        return bcrypt.hashpw(password, bcrypt.gensalt(rounds))
+
+        hashed = bcrypt.hashpw(password, bcrypt.gensalt(rounds))
+        if PYVER < 3:
+            pass
+        else:
+            hashed = hashed.decode('utf-8')
+
+        return hashed
     
     def check_password_hash(self, pw_hash, password):
         '''Tests a password hash against a candidate password. The candidate 
@@ -182,7 +189,13 @@ class Bcrypt(object):
             password = password.decode('utf-8')
 
         if PYVER < 3:
-            password = str(password)
+            if isinstance(pw_hash, unicode):
+                pw_hash = pw_hash.encode('u8')
         else:
-            password = str(password).encode('utf-8')
-        return safe_str_cmp(bcrypt.hashpw(password, pw_hash), pw_hash)
+            password = password.encode('utf-8')
+            pw_hash = pw_hash.encode('utf-8')
+
+        hashed = bcrypt.hashpw(password, pw_hash)
+        hashed = hashed.decode("utf-8")
+
+        return safe_str_cmp(hashed, pw_hash)

--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -155,7 +155,11 @@ class Bcrypt(object):
             password = password.encode('u8')
         elif PYVER >= 3 and isinstance(password, bytes):
             password = password.decode('utf-8')
-        password = str(password)
+
+        if PYVER < 3:
+            password = str(password)
+        else:
+            password = str(password).encode('utf-8')
         return bcrypt.hashpw(password, bcrypt.gensalt(rounds))
     
     def check_password_hash(self, pw_hash, password):
@@ -176,5 +180,9 @@ class Bcrypt(object):
             password = password.encode('u8')
         elif PYVER >= 3 and isinstance(password, bytes):
             password = password.decode('utf-8')
-        password = str(password)
+
+        if PYVER < 3:
+            password = str(password)
+        else:
+            password = str(password).encode('utf-8')
         return safe_str_cmp(bcrypt.hashpw(password, pw_hash), pw_hash)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules=['flask_bcrypt'],
     zip_safe=False,
     platforms='any',
-    install_requires=['Flask', 'py-bcrypt>=0.3'],
+    install_requires=['Flask', 'bcrypt'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -13,11 +13,11 @@ class BasicTestCase(unittest.TestCase):
 
     def test_is_string(self):
         pw_hash = self.bcrypt.generate_password_hash('secret')
-        self.assertTrue(isinstance(pw_hash, bytes))
+        self.assertTrue(isinstance(pw_hash, str))
 
     def test_not_string(self):
         pw_hash = self.bcrypt.generate_password_hash(42)
-        self.assertTrue(isinstance(pw_hash, bytes))
+        self.assertTrue(isinstance(pw_hash, str))
 
     def test_custom_rounds(self):
         password = 'secret'

--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -13,11 +13,11 @@ class BasicTestCase(unittest.TestCase):
 
     def test_is_string(self):
         pw_hash = self.bcrypt.generate_password_hash('secret')
-        self.assertTrue(isinstance(pw_hash, str))
+        self.assertTrue(isinstance(pw_hash, bytes))
 
     def test_not_string(self):
         pw_hash = self.bcrypt.generate_password_hash(42)
-        self.assertTrue(isinstance(pw_hash, str))
+        self.assertTrue(isinstance(pw_hash, bytes))
 
     def test_custom_rounds(self):
         password = 'secret'


### PR DESCRIPTION
I met msvc++ 10.0 error while developing on windows with python3 because of py-bcrypt package.
To solve that problem, I found bcrypt pacakge that doesn't cause error and replace py-bcrypt to bcrypt.