### PR TITLE
Add configuration option for hash prefix

### DIFF
--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -13,6 +13,7 @@ class BasicTestCase(unittest.TestCase):
     def setUp(self):
         app = flask.Flask(__name__)
         app.config['BCRYPT_LOG_ROUNDS'] = 6
+        app.config['BCRYPT_HASH_IDENT'] = '2b'
         self.bcrypt = Bcrypt(app)
 
     def test_is_string(self):


### PR DESCRIPTION
Allows a specific value to be passed to the `prefix` parameter of `bcrypt.gensalt()`.

More details on the values allowed [here](https://github.com/pyca/bcrypt/blob/a78988561896173ee62ae983acbcbaad760c6d6f/src/bcrypt/__init__.py#L39)