### PR TITLE
Ensure bcrypt module v.3.1.1 is used.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules=['flask_bcrypt'],
     zip_safe=False,
     platforms='any',
-    install_requires=['Flask', 'bcrypt'],
+    install_requires=['Flask', 'bcrypt==3.1.1'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
A security issue (BSD wraparound bug) was fixed by the bcrypt package developers in version 3.1.0: https://github.com/reaperhulk/bcrypt/commit/6e94a13e0a684dc52eb4a73dad667ff16617bfc7