### PR TITLE
Allow newer versions of bcrypt to be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ from setuptools import setup
 
 module_path = os.path.join(os.path.dirname(__file__), 'flask_bcrypt.py')
 with open(module_path) as module:
-     for line in module:
-          if line.startswith('__version_info__'):
-               version_line = line
-               break
+    for line in module:
+        if line.startswith('__version_info__'):
+            version_line = line
+            break
 
 __version__ = '.'.join(eval(version_line.split('__version_info__ = ')[-1]))
 
@@ -42,4 +42,3 @@ setup(
     ],
     test_suite='test_bcrypt'
 )
-

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     py_modules=['flask_bcrypt'],
     zip_safe=False,
     platforms='any',
-    install_requires=['Flask', 'bcrypt==3.1.1'],
+    install_requires=['Flask', 'bcrypt>=3.1.1'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Bcrypt's version was locked to 3.1.1 in #43.
This pull request makes Flask-Bcrypt depends on bcrypt version 3.1.1 or newer.