### PR TITLE
docs: Fix simple typo, prevelance -> prevalence

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Flask-Bcrypt
 Flask-Bcrypt is a Flask extension that provides bcrypt hashing utilities for
 your application.
 
-Due to the recent increased prevelance of powerful hardware, such as modern
+Due to the recent increased prevalence of powerful hardware, such as modern
 GPUs, hashes have become increasingly easy to crack. A proactive solution to
 this is to use a hash that was designed to be "de-optimized". Bcrypt is such
 a hashing facility; unlike hashing algorithms such as MD5 and SHA1, which are


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `prevalence` rather than `prevelance`.

