### PR TITLE
Deprecated werkzeug.security.safe_str_cm replaced with hmac.compare_digest

### DIFF
--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -18,7 +18,7 @@ __license__ = 'BSD'
 __copyright__ = '(c) 2011 by Max Countryman'
 __all__ = ['Bcrypt', 'check_password_hash', 'generate_password_hash']
 
-from werkzeug.security import safe_str_cmp
+import hmac
 
 try:
     import bcrypt
@@ -232,4 +232,4 @@ class Bcrypt(object):
             password = hashlib.sha256(password).hexdigest()
             password = self._unicode_to_bytes(password)
 
-        return safe_str_cmp(bcrypt.hashpw(password, pw_hash), pw_hash)
+        return hmac.compare_digest(bcrypt.hashpw(password, pw_hash), pw_hash)


### PR DESCRIPTION
As per https://github.com/maxcountryman/flask-bcrypt/issues/69 , `check_password_hash` uses the method `werkzeug.security.safe_str_cm` which has been marked as deprecated. I'm following Werkzeug's recommendations to replace the call to `safe_str_cm` with `hmac.check_password_hash`.