### PR TITLE
Create GitHub Action for automatic releases to PyPi

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,26 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Prepare Env
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,3 +24,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,4 +24,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lib/*
 src/*
 !.gitignore
 venv*
+!.github

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,13 @@
-'''
-    Flask-Bcrypt
-    ------------
-
-    Bcrypt hashing for your Flask.
-'''
-
 import os
 
 from setuptools import setup
 
-module_path = os.path.join(os.path.dirname(__file__), 'flask_bcrypt.py')
-with open(module_path) as module:
-    for line in module:
-        if line.startswith('__version_info__'):
-            version_line = line
-            break
+this_directory = os.path.dirname(__file__)
+module_path = os.path.join(this_directory, 'flask_bcrypt.py')
+version_line = [line for line in open(module_path)
+                if line.startswith('__version_info__')][0]
+with open(os.path.join(this_directory, 'README.markdown')) as f:
+    long_description = f.read()
 
 __version__ = '.'.join(eval(version_line.split('__version_info__ = ')[-1]))
 
@@ -26,7 +19,8 @@ setup(
     author='Max Countryman',
     author_email='maxc@me.com',
     description='Brcrypt hashing for Flask.',
-    long_description=__doc__,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     py_modules=['flask_bcrypt'],
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
I wanted to use the latest version of flask-login and flask-bcrypt with my project but pipenv does not support installing directly from `git+https://zbx.cyx` when there are no egg files present. 

This patch follows the design of flask-seasurf. I have tested it on a [test index of PyPi](https://test.pypi.org/project/Flask-Bcrypt/).

Changes Made:
* Add Readme as long description for PyPi
* Dropped 2.6 and 3.3 from TravisCI (TravisCI cannot download those Python versions so the tests fail )
* Add GitHub Action to Push to PyPi when a new Tag/Release is created in the form of (9.9.9)

Please add your `PYPI_API_TOKEN` Secret to the repository before merging.
