### PR TITLE
Allow overriding _handle_long_passwords

### DIFF
--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -163,7 +163,7 @@ class Bcrypt(object):
             bytes_object = unicode_string
         return bytes_object
 
-    def generate_password_hash(self, password, rounds=None, prefix=None):
+    def generate_password_hash(self, password, rounds=None, prefix=None, handle_long_passwords=None):
         '''Generates a password hash using bcrypt. Specifying `rounds`
         sets the log_rounds parameter of `bcrypt.gensalt()` which determines
         the complexity of the salt. 12 is the default value. Specifying `prefix`
@@ -178,6 +178,7 @@ class Bcrypt(object):
         :param password: The password to be hashed.
         :param rounds: The optional number of rounds.
         :param prefix: The algorithm version to use.
+        :param handle_long_passwords: Enable prehashing with SHA256
         '''
 
         if not password:
@@ -192,14 +193,17 @@ class Bcrypt(object):
         password = self._unicode_to_bytes(password)
         prefix = self._unicode_to_bytes(prefix)
 
-        if self._handle_long_passwords:
+        if handle_long_passwords is None:
+            handle_long_passwords = self._handle_long_passwords
+
+        if handle_long_passwords:
             password = hashlib.sha256(password).hexdigest()
             password = self._unicode_to_bytes(password)
 
         salt = bcrypt.gensalt(rounds=rounds, prefix=prefix)
         return bcrypt.hashpw(password, salt)
 
-    def check_password_hash(self, pw_hash, password):
+    def check_password_hash(self, pw_hash, password, handle_long_passwords=None):
         '''Tests a password hash against a candidate password. The candidate
         password is first hashed and then subsequently compared in constant
         time to the existing hash. This will either return `True` or `False`.
@@ -212,13 +216,17 @@ class Bcrypt(object):
 
         :param pw_hash: The hash to be compared against.
         :param password: The password to compare.
+        :param handle_long_passwords: Enable prehashing with SHA256
         '''
 
         # Python 3 unicode strings must be encoded as bytes before hashing.
         pw_hash = self._unicode_to_bytes(pw_hash)
         password = self._unicode_to_bytes(password)
 
-        if self._handle_long_passwords:
+        if handle_long_passwords is None:
+            handle_long_passwords = self._handle_long_passwords
+
+        if handle_long_passwords:
             password = hashlib.sha256(password).hexdigest()
             password = self._unicode_to_bytes(password)
 

--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -65,12 +65,12 @@ class BasicTestCase(unittest.TestCase):
         self.assertTrue(self.bcrypt.check_password_hash(pw_hash, 'A' * 80))
 
     def test_custom_long_password(self):
-        """Test the work around bcrypt maximum password length when set explicitly."""
+        """Test the work around bcrypt maximum password length when set explicitly to True."""
 
         # Create a password with a 72 bytes length
         password = 'A' * 72
         pw_hash = self.bcrypt.generate_password_hash(password, handle_long_passwords=True)
-        # Ensure that a longer password yields the same hash
+        # Ensure that a longer password *does not* yield the same hash
         self.assertFalse(self.bcrypt.check_password_hash(pw_hash, 'A' * 80, handle_long_passwords=True))
 
 
@@ -89,11 +89,11 @@ class LongPasswordsTestCase(BasicTestCase):
         # Create a password with a 72 bytes length
         password = 'A' * 72
         pw_hash = self.bcrypt.generate_password_hash(password)
-        # Ensure that a longer password **do not** yield the same hash
+        # Ensure that a longer password **does not** yield the same hash
         self.assertFalse(self.bcrypt.check_password_hash(pw_hash, 'A' * 80))
 
     def test_custom_long_password(self):
-        """Test the work around bcrypt maximum password length when set explicitly."""
+        """Test the work around bcrypt maximum password length when set explicitly to False."""
 
         # Create a password with a 72 bytes length
         password = 'A' * 72

--- a/test_bcrypt.py
+++ b/test_bcrypt.py
@@ -64,6 +64,15 @@ class BasicTestCase(unittest.TestCase):
         # Ensure that a longer password yields the same hash
         self.assertTrue(self.bcrypt.check_password_hash(pw_hash, 'A' * 80))
 
+    def test_custom_long_password(self):
+        """Test the work around bcrypt maximum password length when set explicitly."""
+
+        # Create a password with a 72 bytes length
+        password = 'A' * 72
+        pw_hash = self.bcrypt.generate_password_hash(password, handle_long_passwords=True)
+        # Ensure that a longer password yields the same hash
+        self.assertFalse(self.bcrypt.check_password_hash(pw_hash, 'A' * 80, handle_long_passwords=True))
+
 
 class LongPasswordsTestCase(BasicTestCase):
 
@@ -82,6 +91,15 @@ class LongPasswordsTestCase(BasicTestCase):
         pw_hash = self.bcrypt.generate_password_hash(password)
         # Ensure that a longer password **do not** yield the same hash
         self.assertFalse(self.bcrypt.check_password_hash(pw_hash, 'A' * 80))
+
+    def test_custom_long_password(self):
+        """Test the work around bcrypt maximum password length when set explicitly."""
+
+        # Create a password with a 72 bytes length
+        password = 'A' * 72
+        pw_hash = self.bcrypt.generate_password_hash(password, handle_long_passwords=False)
+        # Ensure that a longer password yields the same hash
+        self.assertTrue(self.bcrypt.check_password_hash(pw_hash, 'A' * 80, handle_long_passwords=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This introduces an optional parameter for the `generate_password_hash` and `check_password_hash` member functions. It overrides the default set by `BCRYPT_HANDLE_LONG_PASSWORDS`. As mentioned in #45 it might introduce a bit more complexity, but there are reasonable use cases for this, e.g.:

* If you did not allow long passwords in the past and want to transition to allowing it afterwards in your already deployed application.
* If you want to support long passwords but want to reduce computational cost as most users don't use 72-byte passwords.

Both cases require the option to use both methods in the same application which was currently not possible (or at least not in a simple way as it required two instances of `flask_bcrypt.Bcrypt()` and manually overriding the "protected" `_handle_long_passwords` variable on one of those).