### PR TITLE
Use bcrypt's built-in function for checking the password hash

### DIFF
--- a/flask_bcrypt.py
+++ b/flask_bcrypt.py
@@ -221,5 +221,5 @@ class Bcrypt(object):
         if self._handle_long_passwords:
             password = hashlib.sha256(password).hexdigest()
             password = self._unicode_to_bytes(password)
-
-        return hmac.compare_digest(bcrypt.hashpw(password, pw_hash), pw_hash)
+        
+        return bcrypt.checkpw(password, pw_hash)


### PR DESCRIPTION
Right now the method `check_password_hash` uses `hmac.compare_digest(bcrypt.hashpw(password, pw_hash), pw_hash)` to check if the password matches the provided hash. This is exactly how the bcrypt module implements its `checkpw` function. For the sake of reducing code duplication this should be replaced with bcrypt's provided function.